### PR TITLE
Change databases list to dict in example_config to match expected value

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -12,13 +12,13 @@ Layer recipe configuration is provided by means of a folder containing one or mo
 
 The server configuration file sets several important parameters for your app.
 
-#### databases (list) - *required*
+#### databases (dict) - *required*
 
 At least one database connection must be provided. Use the `default` key for your primary (or only) database.
 
     databases:
-    - default: dsn_connection_string
-    - another_db: another_dsn_connection_string
+      default: dsn_connection_string
+      another_db: another_dsn_connection_string
 
 The DSN strings are per the [LibPQ connection string format](http://www.postgresql.org/docs/current/static/libpq-connect.html#LIBPQ-CONNSTRING)
 

--- a/example_configs/example_server_configs.yaml
+++ b/example_configs/example_server_configs.yaml
@@ -1,5 +1,5 @@
 databases:
-- default: 'dbname=my_db user=my_user password= host=localhost'
+  default: 'dbname=my_db user=my_user password= host=localhost'
 default_recipe: 'example_recipe'
 log_level: 'info'
 SRID: 3857  # optional global parameter


### PR DESCRIPTION
Tried using the Docker approach but got an AttributeError on build -- the `databases` option had a list instead of a dict as the example.

```
Traceback (most recent call last):
  File "/aiovectortiler/aiovectortiler/serve.py", line 166, in <module>
    serve_tiles(args.server_configs, args.layer_recipes, args.host, args.port)
  File "/aiovectortiler/aiovectortiler/serve.py", line 130, in serve_tiles
    for db_name, dsn_string in Configs.server['databases'].items():
AttributeError: 'list' object has no attribute 'items'
```

Changed to a dict and it worked.
